### PR TITLE
comskip_wrapper.sh: センチ秒のサポート

### DIFF
--- a/misc/comskip_wrapper.sh
+++ b/misc/comskip_wrapper.sh
@@ -45,17 +45,21 @@ fi
 VDR_FILE="`pwd`/${FILE_NAME}vdr"
 LINE_NO=1
 
-# 'CM' begin time
-BEGIN_TIME=""
-# 'CM' end time
-_END__TIME=""
+# 'CM' begin centisec time
+BEGIN_CSEC=""
+# 'CM' end centisec time
+_END__CSEC=""
 
-# main knitting begin time array
-BEGIN_TIME_ARRAY=()
-# main knitting end time array
-_END__TIME_ARRAY=()
+# main knitting begin centisec time array
+BEGIN_CSEC_ARRAY=()
+# main knitting end centisec time array
+_END__CSEC_ARRAY=()
 
-for LINE in `cat "${VDR_FILE}" | awk {'print $1'}`;
+_IFS="${IFS}"
+IFS=":. "
+exec 9<"${VDR_FILE}"
+# <hour>:<min>:<sec>.<centisec> (start|end)
+while read -u9 hour min sec centisec ignore;
 do
     if test ${LINE_NO} = 1; then
         # skip first line
@@ -63,17 +67,21 @@ do
 	continue
     fi
 
+    # calculate centisecond time
+    _CSEC=`expr \( \( ${hour} \* 60 + ${min} \) \* 60 + ${sec} \) \* 100 + ${centisec}`
+    #echo "DEBUG: $hour:$min:$sec.$centisec -> ${_CSEC}"
+
     if `expr \( ${LINE_NO} % 2 \) = 1 > /dev/null`; then
-	BEGIN_TIME="0${LINE}"
-	_END__TIME_ARRAY+=(${BEGIN_TIME})
+	_END__CSEC_ARRAY+=(${_CSEC})
     else
-	_END__TIME="0${LINE}"
-	BEGIN_TIME_ARRAY+=(${_END__TIME})
+	BEGIN_CSEC_ARRAY+=(${_CSEC})
     fi
     LINE_NO=`expr ${LINE_NO} + 1`
 done
+IFS="${_IFS}"
+exec 9<&-
 
-if test ${#_END__TIME_ARRAY[@]} -eq 0; then
+if test ${#_END__CSEC_ARRAY[@]} -eq 0; then
     echo "It seems no commercials is found."
     exit 2
 fi
@@ -81,20 +89,23 @@ fi
 i=0
 CUT_FILE_LIST=()
 
-for _END__TIME in ${_END__TIME_ARRAY[@]}; do
+for _END__CSEC in ${_END__CSEC_ARRAY[@]}; do
+    # _END__CSEC and BEGIN_CSEC is centisec!!
+    BEGIN_CSEC=${BEGIN_CSEC_ARRAY[${i}]}
+    # calculate original time for beginning
+    BEGIN_SEC=`expr ${BEGIN_CSEC} / 100`
+    BEGIN_CENTISEC=`expr ${BEGIN_CSEC} % 100`
+    BEGIN_TIME="${BEGIN_SEC}.${BEGIN_CENTISEC}"
 
-    BEGIN_TIME=${BEGIN_TIME_ARRAY[${i}]}
     let i++
     FILE_PARTS=${i}
-    echo "${FFMPEG} -y -i ${TS_FILE} -c copy -ss ${_END__TIME} -t ${BEGIN_TIME} -sn `pwd`/${FILE_NAME}-${FILE_PARTS}.ts"
     CUT_FILE_LIST+=(`pwd`/"${FILE_NAME}-${FILE_PARTS}.ts")
 
-    # convert time from 1970-01-01 00:00:00(UNIX Time) 
-    DATE_YMD=`date '+%Y/%m/%d'`
-    TIME_BEGIN=`date -d "${DATE_YMD} ${BEGIN_TIME}" "+%s"`
-    TIME__END_=`date -d "${DATE_YMD} ${_END__TIME}" "+%s"`
-    DIFF_SEC=`expr ${TIME__END_} - ${TIME_BEGIN}`
-    PLAY_TIME=`echo | awk -v D=${DIFF_SEC} '{printf "%02d:%02d:%02d",D/(60*60),D%(60*60)/60,D%60}'`
+    DIFF_TIME=`expr ${_END__CSEC} - ${BEGIN_CSEC}`
+    DIFF_SEC=`expr ${DIFF_TIME} / 100`
+    DIFF_CENTISEC=`expr ${DIFF_TIME} % 100`
+    PLAY_TIME="${DIFF_SEC}.${DIFF_CENTISEC}"
+    #echo "DEBUG: $_END__CSEC - $BEGIN_CSEC = ${DIFF_SEC}.${DIFF_CENTISEC}"
     #mkfifo "$(pwd)/${FILE_NAME}-${FILE_PARTS}.ts"
     # ffmpeg -i <input_data> -ss <start_sec> -t <play_time> <output_data>
     echo "${FFMPEG} -y -i ${TS_FILE} -c copy -ss ${BEGIN_TIME} -t ${PLAY_TIME} -sn `pwd`/${FILE_NAME}-${FILE_PARTS}.ts"


### PR DESCRIPTION
まとまった pullreq でごめんなさい。

この pullreq の変更点は次の通りです。
-   CMらしきものが見つからなかったときに exit 2 する
  
  CMが見当たらなかったときに、最後のffmpegに concat: のみが渡されてエラーになることへの対応です。
  
  終了コードが2なのは、エラーと分けた方がいいかなと思ったからですが、
  他でexitするところがないので1でもいいとは思います。
-   変数展開をdouble quote markで括った
  
  半角空白を渡されたときに備えてです。
-   時間パラメータをcentisecでffmpegに渡す
  
  BEGIN_TIME_ARRAY (BEGIN_CSEC_ARRAY) 等の各要素がセンチ秒 (整数) になっています。
  
  このままでは渡せないのでパラメータとして渡す時に 秒.センチ秒 に変換しています。

こちらでは、ffmpeg 1.2.3, libav 9-2741-g09cb75c で最後まで動くことを確認しましたが、
出力ファイルの目視確認等はしておりません。

よろしければマージをおねがいします。
