### PR TITLE
fix possible buffer-overrun

### DIFF
--- a/mpeg2dec.c
+++ b/mpeg2dec.c
@@ -1563,8 +1563,12 @@ int main (int argc, char ** argv)
         }
         strncpy(HomeDir, ptr, len);
 
-        len = (size_t)max(0,strrchr(HomeDir,'\\') - HomeDir);
-        if (len==0)
+        char* HomeDirSeparator = strrchr(HomeDir, '/');
+        if (HomeDirSeparator == NULL)
+        {
+            HomeDirSeparator = strrchr(HomeDir, '\\');
+        }
+        if (HomeDirSeparator == NULL)
         {
             HomeDir[0] = '.';
             HomeDir[1] = '\0';


### PR DESCRIPTION
comskip起動中に発生するバッファオーバーランを解消します。

このバッファオーバーランによりASLR環境下で確率的にSegmentation Faultが発生していました。
バッファオーバーラン自体は非ASLRでも発生していたようです。